### PR TITLE
refactor: make hyprland module system-agnostic using hostname variable

### DIFF
--- a/modules/home/programs/hypridle.nix
+++ b/modules/home/programs/hypridle.nix
@@ -1,4 +1,10 @@
-{ config, lib, pkgs, userVars, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
 
 let
   inherit (lib) mkEnableOption mkIf;
@@ -7,7 +13,9 @@ let
   hyprlandCfg = config.modules.programs.hyprland;
   configRoot = "/home/${userVars.username}/.config/nixos";
   configscriptsDir = "${configRoot}/scripts";
-  barCfg = userVars.hyprland.bar or "hyprpanel";  # Default to hyprpanel if not specified
+  barCfg = userVars.hyprland.bar or "hyprpanel"; # Default to hyprpanel if not specified
+  hostName = userVars.hostName or "orion"; # Default to orion for backward compatibility
+  systemScriptsDir = "${configRoot}/systems/${hostName}/scripts";
 in
 {
   options.modules.programs.hypridle.enable = mkEnableOption "Hypridle idle daemon";
@@ -20,7 +28,7 @@ in
         general = {
           lock_cmd = "pidof hyprlock || hyprlock"; # avoid starting multiple hyprlock instances.
           before_sleep_cmd = "loginctl lock-session"; # lock before suspend.
-          after_sleep_cmd = "hyprctl dispatch dpms on && ${configRoot}/systems/orion/scripts/monitor-handler.sh --fast --bar=${barCfg}"; # restore display and monitors after suspend.
+          after_sleep_cmd = "hyprctl dispatch dpms on && ${systemScriptsDir}/monitor-handler.sh --fast --bar=${barCfg}"; # restore display and monitors after suspend.
           ignore_dbus_inhibit = false; # respect app inhibitors (e.g., video playback)
         };
 

--- a/systems/orion/default.nix
+++ b/systems/orion/default.nix
@@ -44,7 +44,9 @@ in
     useUserPackages = true;
     extraSpecialArgs = {
       inherit inputs;
-      userVars = systemVars.user;
+      userVars = systemVars.user // {
+        inherit hostName;
+      };
       opencode = inputs.opencode.packages.${pkgs.system};
     };
     # Auto back up files that would be clobbered by Home Manager so that


### PR DESCRIPTION
Replace hardcoded 'orion' paths in hyprland and hypridle modules with dynamic hostname variable. This allows the modules to be used on any system without modification.

Changes:
- modules/home/programs/hyprland.nix: Use hostName variable for script paths
- modules/home/programs/hypridle.nix: Use hostName variable for script paths
- systems/orion/default.nix: Pass hostName through extraSpecialArgs

The modules now dynamically reference:
  systems/${hostName}/scripts/start-waybar.sh systems/${hostName}/scripts/start-hyprpanel.sh systems/${hostName}/scripts/monitor-handler.sh

Defaults to 'orion' for backward compatibility when hostName is not provided.

This enables hyprland to be used on other systems (cortex, axon, etc.) by ensuring each system has its own scripts directory at systems/<hostname>/scripts/