### PR TITLE
fix: update Axon configuration to fix NixOS 26.05 deprecation warnings

### DIFF
--- a/systems/axon/default.nix
+++ b/systems/axon/default.nix
@@ -95,7 +95,7 @@ in
   };
 
   # Audio configuration optimized for Axon
-  hardware.pulseaudio.enable = false;
+  services.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {
     enable = true;
@@ -180,24 +180,24 @@ in
   services = {
     xserver = {
       enable = true;
-      displayManager = {
-        gdm = {
-          enable = true;
-          autoSuspend = false; # Prevent auto-suspend on Axon
-        };
-      };
-      desktopManager.gnome.enable = true;
     };
+
+    displayManager = {
+      gdm = {
+        enable = true;
+        autoSuspend = false; # Prevent auto-suspend on Axon
+      };
+      autoLogin = {
+        enable = true;
+        user = "kiosk";
+      };
+    };
+
+    desktopManager.gnome.enable = true;
 
     # Disable GNOME tracker for performance
-    gnome.tracker.enable = false;
-    gnome.tracker-miners.enable = false;
-
-    # Auto-login for kiosk user
-    displayManager.autoLogin = {
-      enable = true;
-      user = "kiosk";
-    };
+    gnome.tinysparql.enable = false;
+    gnome.localsearch.enable = false;
   };
 
   # Kiosk mode service - launches Jellyfin directly on boot

--- a/systems/axon/homes/axon.nix
+++ b/systems/axon/homes/axon.nix
@@ -1,5 +1,11 @@
- # Home Manager configuration for Axon admin user
-{ config, pkgs, inputs, userVars, ... }:
+# Home Manager configuration for Axon admin user
+{
+  config,
+  pkgs,
+  inputs,
+  userVars,
+  ...
+}:
 
 {
   # Basic user info
@@ -31,8 +37,12 @@
 
   programs.git = {
     enable = true;
-    userName = userVars.name;
-    userEmail = userVars.email;
+    settings = {
+      user = {
+        name = userVars.name;
+        email = userVars.email;
+      };
+    };
   };
 
   programs.zsh = {
@@ -47,7 +57,7 @@
       cat = "bat";
       cd = "z";
     };
-    initExtra = ''
+    initContent = ''
       eval "$(starship init zsh)"
       eval "$(zoxide init zsh)"
     '';
@@ -71,7 +81,7 @@
   programs.firefox = {
     enable = true;
     profiles.default = {
-  name = "Axon";
+      name = "Axon";
       settings = {
         "media.ffmpeg.vaapi.enabled" = true;
         "media.hardware-video-decoding.force-enabled" = true;


### PR DESCRIPTION
- Update git config: userName/userEmail → settings.user.name/email
- Update zsh: initExtra → initContent
- Update display manager paths: services.xserver.{displayManager,desktopManager} → services.{displayManager,desktopManager}
- Update GNOME services: tracker → tinysparql, tracker-miners → localsearch
- Update audio: hardware.pulseaudio → services.pulseaudio