### PR TITLE
refactor: migrate to flake-parts for modular flake composition (Phase 1)

### DIFF
--- a/flake-modules/deploy.nix
+++ b/flake-modules/deploy.nix
@@ -1,0 +1,37 @@
+{ self, inputs, ... }:
+{
+  flake.deploy = {
+    sshUser = "jarvis"; # Global SSH user for all nodes
+
+    nodes = {
+      cortex = {
+        hostname = "192.168.1.7"; # TODO: Switch to cortex.home when DNS is fixed
+        profiles.system = {
+          path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.cortex;
+          user = "root"; # Activate as root (via sudo)
+        };
+      };
+      nexus = {
+        hostname = "192.168.1.22"; # Nexus homelab services server
+        sshUser = "admin"; # Override global SSH user for Nexus
+        profiles.system = {
+          path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.nexus;
+          user = "root"; # Activate as root (via sudo)
+        };
+      };
+      axon = {
+        hostname = "192.168.1.11"; # TODO: Update with actual Axon IP
+        profiles.system = {
+          path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos self.nixosConfigurations.axon;
+          user = "root"; # Activate as root (via sudo)
+        };
+      };
+      # Add other systems here as needed
+    };
+  };
+
+  # Add deploy-rs checks
+  flake.checks = builtins.mapAttrs (
+    system: deployLib: deployLib.deployChecks self.deploy
+  ) inputs.deploy-rs.lib;
+}

--- a/flake-modules/home-configurations.nix
+++ b/flake-modules/home-configurations.nix
@@ -1,0 +1,34 @@
+{ self, inputs, ... }:
+let
+  system = "x86_64-linux";
+  inherit (inputs.nixpkgs.legacyPackages.${system}) pkgs;
+
+  # Import variables for home-manager
+  variables = import ../systems/orion/variables.nix;
+  inherit (variables.user) username;
+  userVars = variables.user;
+  systemVars = variables.system;
+
+  mkHomeConfiguration =
+    variables:
+    inputs.home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      extraSpecialArgs = {
+        inherit self inputs userVars;
+        opencode = inputs.opencode.packages.${system};
+      };
+      modules = [
+        inputs.nix-flatpak.homeManagerModules.nix-flatpak
+        ../systems/orion/homes/syg.nix
+        {
+          nixpkgs.config.allowUnfree = true;
+        }
+      ];
+    };
+in
+{
+  flake.homeConfigurations = {
+    ${username} = mkHomeConfiguration userVars;
+    "${username}@${systemVars.hostName}" = mkHomeConfiguration userVars;
+  };
+}

--- a/flake-modules/home-configurations.nix
+++ b/flake-modules/home-configurations.nix
@@ -1,20 +1,18 @@
 { self, inputs, ... }:
 let
-  system = "x86_64-linux";
+  # Import shared constants
+  shared = import ./lib.nix { inherit inputs; };
+  inherit (shared) system userVars systemVars;
+
   inherit (inputs.nixpkgs.legacyPackages.${system}) pkgs;
 
-  # Import variables for home-manager
-  variables = import ../systems/orion/variables.nix;
-  inherit (variables.user) username;
-  userVars = variables.user;
-  systemVars = variables.system;
-
   mkHomeConfiguration =
-    variables:
+    _userVars:
     inputs.home-manager.lib.homeManagerConfiguration {
       inherit pkgs;
       extraSpecialArgs = {
-        inherit self inputs userVars;
+        inherit self inputs;
+        userVars = _userVars;
         opencode = inputs.opencode.packages.${system};
       };
       modules = [
@@ -28,7 +26,7 @@ let
 in
 {
   flake.homeConfigurations = {
-    ${username} = mkHomeConfiguration userVars;
-    "${username}@${systemVars.hostName}" = mkHomeConfiguration userVars;
+    ${userVars.username} = mkHomeConfiguration userVars;
+    "${userVars.username}@${systemVars.hostName}" = mkHomeConfiguration userVars;
   };
 }

--- a/flake-modules/lib.nix
+++ b/flake-modules/lib.nix
@@ -1,0 +1,19 @@
+# Shared constants and utilities for flake modules
+{ inputs, ... }:
+let
+  # System architecture - defined once for consistency
+  system = "x86_64-linux";
+
+  # Import variables for home-manager - shared across modules
+  variables = import ../systems/orion/variables.nix;
+  userVars = variables.user;
+  systemVars = variables.system;
+in
+{
+  inherit
+    system
+    variables
+    userVars
+    systemVars
+    ;
+}

--- a/flake-modules/nixos-configurations.nix
+++ b/flake-modules/nixos-configurations.nix
@@ -1,7 +1,10 @@
 { self, inputs, ... }:
 let
   inherit (inputs.nixpkgs) lib;
-  system = "x86_64-linux";
+
+  # Import shared constants
+  shared = import ./lib.nix { inherit inputs; };
+  inherit (shared) system userVars;
 
   # List all systems here for easy extensibility
   systems = {
@@ -44,11 +47,6 @@ let
     };
     # Add new systems here!
   };
-
-  # Import variables for home-manager
-  variables = import ../systems/orion/variables.nix;
-  inherit (variables.user) username;
-  userVars = variables.user;
 in
 {
   flake.nixosConfigurations = lib.mapAttrs (

--- a/flake-modules/nixos-configurations.nix
+++ b/flake-modules/nixos-configurations.nix
@@ -1,0 +1,71 @@
+{ self, inputs, ... }:
+let
+  inherit (inputs.nixpkgs) lib;
+  system = "x86_64-linux";
+
+  # List all systems here for easy extensibility
+  systems = {
+    orion = {
+      path = ../systems/orion;
+      modules = [
+        inputs.stylix.nixosModules.stylix
+        inputs.nix-snapd.nixosModules.default
+        inputs.nixos-hardware.nixosModules.framework-13-7040-amd
+        inputs.home-manager.nixosModules.home-manager
+        inputs.sops-nix.nixosModules.sops
+      ];
+      hasSecrets = true;
+    };
+    cortex = {
+      path = ../systems/cortex;
+      modules = [
+        inputs.disko.nixosModules.disko
+        inputs.home-manager.nixosModules.home-manager
+        inputs.sops-nix.nixosModules.sops
+      ];
+      hasSecrets = true;
+    };
+    nexus = {
+      path = ../systems/nexus;
+      modules = [
+        inputs.disko.nixosModules.disko
+        inputs.home-manager.nixosModules.home-manager
+        inputs.sops-nix.nixosModules.sops
+      ];
+      hasSecrets = true;
+    };
+    axon = {
+      path = ../systems/axon;
+      modules = [
+        inputs.stylix.nixosModules.stylix
+        inputs.home-manager.nixosModules.home-manager
+      ];
+      hasSecrets = false;
+    };
+    # Add new systems here!
+  };
+
+  # Import variables for home-manager
+  variables = import ../systems/orion/variables.nix;
+  inherit (variables.user) username;
+  userVars = variables.user;
+in
+{
+  flake.nixosConfigurations = lib.mapAttrs (
+    name: cfg:
+    inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [ cfg.path ] ++ cfg.modules;
+      specialArgs = {
+        inherit
+          self
+          system
+          inputs
+          userVars
+          ;
+        fh = inputs.fh;
+        hasSecrets = cfg.hasSecrets;
+      };
+    }
+  ) systems;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -276,6 +276,24 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
         "lastModified": 1715865404,
         "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
         "owner": "hercules-ci",
@@ -289,7 +307,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
@@ -781,7 +799,7 @@
     "nix-snapd": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -845,6 +863,21 @@
       }
     },
     "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1714640452,
         "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
@@ -1054,6 +1087,7 @@
         "devenv-bootstrap": "devenv-bootstrap",
         "disko": "disko",
         "fh": "fh",
+        "flake-parts": "flake-parts",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "import-tree": "import-tree",
@@ -1112,7 +1146,7 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "gnome-shell": "gnome-shell",
         "nixpkgs": "nixpkgs_8",
         "nur": "nur",


### PR DESCRIPTION
- Add flake-parts input and restructure flake.nix
- Create flake-modules/ directory with modular structure:
  - nixos-configurations.nix: All system definitions
  - home-configurations.nix: Standalone home-manager configs
  - deploy.nix: deploy-rs configuration
- Add per-system outputs (formatter, devShells)
- All 4 systems (orion, cortex, nexus, axon) build successfully
- Maintains backward compatibility with existing system configs

This completes Phase 1 of the flake-parts + dendritic migration. Next: Phase 2 will merge split system/home configs into unified feature modules.