### PR TITLE
feat: migrate Axon to unified zsh feature module

### DIFF
--- a/systems/axon/default.nix
+++ b/systems/axon/default.nix
@@ -179,6 +179,7 @@ in
     # Hyprland disabled - using GNOME for Axon simplicity
     features = {
       hyprland.enable = false;
+      zsh.enable = true;
     };
   };
 

--- a/systems/axon/homes/axon.nix
+++ b/systems/axon/homes/axon.nix
@@ -28,11 +28,7 @@
     remmina
     nemo-with-extensions
     alacritty
-    starship
-    zoxide
-    fzf
-    eza
-    bat
+    # Note: starship, zoxide, fzf, eza, bat provided by features.zsh module
   ];
 
   programs.git = {
@@ -45,23 +41,8 @@
     };
   };
 
-  programs.zsh = {
-    enable = true;
-    enableCompletion = true;
-    autosuggestion.enable = true;
-    syntaxHighlighting.enable = true;
-    shellAliases = {
-      ll = "eza -l";
-      la = "eza -la";
-      tree = "eza --tree";
-      cat = "bat";
-      cd = "z";
-    };
-    initContent = ''
-      eval "$(starship init zsh)"
-      eval "$(zoxide init zsh)"
-    '';
-  };
+  # Zsh configuration now managed by features.zsh module via dotfiles
+  # See: modules/features/zsh.nix and dotfiles/.config/zsh/
 
   programs.starship = {
     enable = true;


### PR DESCRIPTION
- Enable features.zsh for Axon system
- Remove declarative programs.zsh configuration from axon.nix
- Remove duplicate packages (starship, zoxide, fzf, eza, bat)
- Keep programs.starship declarative config (doesn't conflict)
- Kiosk user unaffected (uses bash, not zsh)

This completes the migration to the dendritic pattern for zsh across all systems. Both Orion and Axon now use the unified feature module with dotfiles-based configuration.