### PR TITLE
feat: add GitHub CLI (gh) to base system packages

### DIFF
--- a/systems/orion/default.nix
+++ b/systems/orion/default.nix
@@ -269,6 +269,7 @@ in
 
       # Enhanced development tools (base has basic git)
       act # gh actions cli
+      gh # GitHub CLI for PR and repo management
       direnv
       lazygit
 


### PR DESCRIPTION
Add gh CLI tool to essential development tools in base module. This provides GitHub operations (PR management, repo queries, etc.) across all systems in the fleet.

Useful for automation and CLI-based GitHub workflows.