### PR TITLE
feat: add GitHub CLI (gh) to Orion development tools

### DIFF
--- a/systems/orion/default.nix
+++ b/systems/orion/default.nix
@@ -269,6 +269,7 @@ in
 
       # Enhanced development tools (base has basic git)
       act # gh actions cli
+      gh # GitHub CLI for PR and repo management
       direnv
       lazygit
 


### PR DESCRIPTION
## Summary

Adds GitHub CLI (`gh`) to Orion's enhanced development tools.

## Changes

- Add `gh` to Orion's systemPackages alongside `act` (GitHub Actions CLI) and `lazygit`
- Only affects Orion (workstation), not server systems (Axon, Cortex, Nexus)

## Benefits

- Create and manage PRs from the command line
- Query repos, issues, and workflow runs
- Useful for automation and CLI-based GitHub workflows
- Complements existing tools (`act`, `lazygit`)

## Rationale

Only installed on Orion since that's where development work happens. Server systems don't need GitHub CLI capabilities.