### PR TITLE
feat: migrate dev tools to unified features (Phase 2)

### DIFF
--- a/modules/features/btop.nix
+++ b/modules/features/btop.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.modules.features.btop;
+in
+{
+  options.modules.features.btop.enable =
+    mkEnableOption "btop system monitor with dotfiles configuration";
+
+  config = mkIf cfg.enable {
+    home-manager.users.${userVars.username} =
+      { config, ... }:
+      let
+        inherit (config.lib.file) mkOutOfStoreSymlink;
+        configRoot = "/home/${userVars.username}/.config/nixos";
+      in
+      {
+        home.packages = [ pkgs.btop ];
+
+        home.file.".config/btop/btop.conf" = {
+          source = mkOutOfStoreSymlink "${configRoot}/dotfiles/.config/btop/btop.conf";
+          force = true;
+        };
+      };
+  };
+}

--- a/modules/features/devenv.nix
+++ b/modules/features/devenv.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.modules.features.devenv;
+in
+{
+  options.modules.features.devenv.enable = mkEnableOption "devenv - Fast, Declarative, Reproducible Development Environments";
+
+  config = mkIf cfg.enable {
+    home-manager.users.${userVars.username} = {
+      home.packages = with pkgs; [
+        devenv
+        cachix # Required by devenv for binary caches
+      ];
+    };
+  };
+}

--- a/modules/features/git.nix
+++ b/modules/features/git.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  lib,
+  userVars,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  gitUsername = userVars.git.username;
+  gitEmail = userVars.git.email;
+  cfg = config.modules.features.git;
+in
+{
+  options.modules.features.git.enable =
+    mkEnableOption "Git version control with dotfiles configuration";
+
+  config = mkIf cfg.enable {
+    home-manager.users.${userVars.username} = {
+      home.packages = [ pkgs.git ];
+
+      xdg.configFile."git/config" = {
+        text = import ../../dotfiles/.config/git/config.nix { inherit gitUsername gitEmail; };
+      };
+    };
+  };
+}

--- a/modules/features/kitty.nix
+++ b/modules/features/kitty.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.modules.features.kitty;
+in
+{
+  options.modules.features.kitty.enable =
+    mkEnableOption "Kitty terminal emulator with dotfiles configuration";
+
+  config = mkIf cfg.enable {
+    home-manager.users.${userVars.username} =
+      { config, ... }:
+      {
+        home =
+          let
+            inherit (config.lib.file) mkOutOfStoreSymlink;
+            configRoot = "/home/${userVars.username}/.config/nixos";
+            configKittyDir = "${configRoot}/dotfiles/.config/kitty";
+          in
+          {
+            packages = [ pkgs.kitty ];
+            file = {
+              ".config/kitty/kitty.conf" = {
+                source = mkOutOfStoreSymlink "${configKittyDir}/kitty.conf";
+                force = true;
+              };
+              ".config/kitty/base16-catppuccin-mocha.conf" = {
+                source = mkOutOfStoreSymlink "${configKittyDir}/base16-catppuccin-mocha.conf";
+                force = true;
+              };
+            };
+          };
+      };
+  };
+}

--- a/modules/features/vscode.nix
+++ b/modules/features/vscode.nix
@@ -1,0 +1,133 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+  cfg = config.modules.features.vscode;
+in
+{
+  options.modules.features.vscode = {
+    enable = mkEnableOption "Visual Studio Code code editor";
+
+    variant = mkOption {
+      type = types.enum [
+        "standard"
+        "fhs"
+      ];
+      default = "fhs";
+      description = ''
+        VS Code variant to use:
+        - standard: Declarative extension management
+        - fhs: FHS environment for imperative extension management
+      '';
+    };
+
+    copilotPrompts.enable = mkEnableOption "VS Code Copilot Chat prompts and instructions";
+  };
+
+  config = mkIf cfg.enable {
+    home-manager.users.${userVars.username} =
+      { config, ... }:
+      {
+        home.packages =
+          if cfg.variant == "fhs" then
+            [ pkgs.vscode-fhs ]
+          else
+            [
+              (pkgs.vscode-with-extensions.override {
+                vscodeExtensions =
+                  with pkgs.vscode-extensions;
+                  [
+                    # themes
+                    dracula-theme.theme-dracula
+
+                    # syntax
+                    jnoortheen.nix-ide
+                    bbenoist.nix
+                    astro-build.astro-vscode
+                    svelte.svelte-vscode
+                    bradlc.vscode-tailwindcss
+                    yzhang.markdown-all-in-one
+
+                    # productivity
+                    streetsidesoftware.code-spell-checker
+                    usernamehw.errorlens
+                    dbaeumer.vscode-eslint
+                    alefragnani.project-manager
+                    ryu1kn.partial-diff
+                    timonwong.shellcheck
+
+                    # git
+                    mhutchie.git-graph
+
+                    # copilot
+                    github.copilot
+                    github.copilot-chat
+                  ]
+                  ++ pkgs.vscode-utils.extensionsFromVscodeMarketplace [
+                    {
+                      name = "github-local-actions";
+                      publisher = "sanjulaganepola";
+                      version = "1.2.5";
+                      sha256 = "sha256-gc3iOB/ibu4YBRdeyE6nmG72RbAsV0WIhiD8x2HNCfY=";
+                    }
+                    {
+                      name = "gitless";
+                      publisher = "maattdd";
+                      version = "11.7.2";
+                      sha256 = "sha256-rYeZNBz6HeZ059ksChGsXbuOao9H5m5lHGXJ4ELs6xc=";
+                    }
+                    {
+                      name = "specstory-vscode";
+                      publisher = "specstory";
+                      version = "0.19.1";
+                      sha256 = "sha256-ivCZL7lJ1G3sb2VQyoxO4KdG7dHJldagpYlmYpOdmVo=";
+                    }
+                    {
+                      name = "vscode-kanbn-boards";
+                      publisher = "samgiz";
+                      version = "0.14.1";
+                      sha256 = "sha256-+BIMS5icyEmj1JXKVZmcOfTFI4w/F1zpjbt9ziG7XEk=";
+                    }
+                    {
+                      name = "vscode-versionlens";
+                      publisher = "pflannery";
+                      version = "1.16.2";
+                      sha256 = "sha256-avrq1e+L+2ZCIDBz1WOOHtU9a16VNkDOzrE1ccPnTKg=";
+                    }
+                    {
+                      name = "opencode";
+                      publisher = "sst-dev";
+                      version = "0.0.13";
+                      sha256 = "1m301j2qbym3j2qnck76jyxakca3h1qiybc2r7wy7z11m98mg9z9";
+                    }
+                  ];
+              })
+            ];
+
+        # Symlink entire VS Code Copilot prompts and instructions directories
+        home.file = mkIf cfg.copilotPrompts.enable (
+          let
+            inherit (config.lib.file) mkOutOfStoreSymlink;
+          in
+          {
+            # Symlink entire directories to access all chatmodes and prompts
+            ".config/Code/User/instructions".source =
+              mkOutOfStoreSymlink "${config.home.homeDirectory}/.config/nixos/dotfiles/.config/Code/User/instructions";
+            ".config/Code/User/prompts".source =
+              mkOutOfStoreSymlink "${config.home.homeDirectory}/.config/nixos/dotfiles/.config/Code/User/prompts";
+          }
+        );
+      };
+  };
+}

--- a/modules/home/_base-desktop/default.nix
+++ b/modules/home/_base-desktop/default.nix
@@ -8,5 +8,5 @@
     recursive = true;
   };
 
-  modules.programs.kitty.enable = true;
+  # kitty now managed by unified features.kitty module in system config
 }

--- a/modules/home/_base/default.nix
+++ b/modules/home/_base/default.nix
@@ -21,8 +21,7 @@ in
   modules = {
     programs = {
       # Core utilities - essential for everyone
-      btop.enable = true;
-      git.enable = true;
+      # btop and git now managed by unified features modules in system configs
     };
   };
 

--- a/systems/orion/default.nix
+++ b/systems/orion/default.nix
@@ -143,6 +143,16 @@ in
       hypridle.enable = true;
       waybar.enable = false; # Disabled in favor of hyprpanel
       screenshots.enable = true;
+      # Development tools
+      git.enable = true;
+      kitty.enable = true;
+      btop.enable = true;
+      devenv.enable = true;
+      vscode = {
+        enable = true;
+        variant = "fhs"; # FHS environment for imperative extension management
+        copilotPrompts.enable = true;
+      };
     };
 
     services = {

--- a/systems/orion/homes/syg.nix
+++ b/systems/orion/homes/syg.nix
@@ -68,16 +68,12 @@
   modules.programs = {
     # hyprland now managed by unified features.hyprland module in system config
     # hyprpanel, waybar, hypridle, screenshots now managed by unified features in system config
+    # git, kitty, btop, devenv, vscode now managed by unified features in system config
 
     brave.enable = true;
     librewolf.enable = true;
     firefox.enable = true; # Standard Firefox for work/media (full device access)
     # mullvad-browser now managed by unified features.mullvad module in system config
-    devenv.enable = true; # Development environment manager
-    vscode-fhs = {
-      enable = true;
-      copilotPrompts.enable = true; # Enable curated GitHub Copilot Chat prompts
-    };
     archiver.enable = true; # Enable archive management with Nemo integration
 
     protonmail-bridge = {


### PR DESCRIPTION
## Summary

Continues Phase 2 of the dendritic migration by migrating core development tools to unified feature modules.

## Changes

### New Unified Feature Modules
- **git** - Version control with dotfiles configuration  
- **kitty** - Terminal emulator with dotfiles configuration
- **btop** - System monitor with dotfiles configuration
- **devenv** - Development environment manager
- **vscode** - Code editor with variant support (standard/fhs) and Copilot prompts

### Configuration Updates
- Enable new features in `systems/orion/default.nix`
- Remove old `modules.programs.*` enables from syg.nix home config
- Remove base enables from `modules/home/_base/default.nix` and `_base-desktop/default.nix`

## Benefits

- **Consistent organization**: Dev tools now in `modules/features/`
- **System-level control**: Enable/disable tools at system level
- **Dendritic pattern**: Follows established pattern with dotfiles
- **Flexible vscode**: Support both declarative and FHS variants

## Progress

**Total unified features: 12** (was 7)
- ✅ zsh
- ✅ mullvad  
- ✅ hyprland
- ✅ hyprpanel
- ✅ hypridle
- ✅ waybar
- ✅ screenshots
- ✅ git (new)
- ✅ kitty (new)
- ✅ btop (new)
- ✅ devenv (new)
- ✅ vscode (new)

**Remaining split modules**: ~12 in `modules/home/programs/`, ~6 in `modules/system/services/`