### PR TITLE
Phase 2: Migrate utilities to unified features

### DIFF
--- a/modules/features/archiver.nix
+++ b/modules/features/archiver.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.modules.features.archiver;
+in
+{
+  options.modules.features.archiver.enable =
+    mkEnableOption "archive management with Nemo integration and file-roller";
+
+  config = mkIf cfg.enable {
+    home-manager.users.${userVars.username} = {
+      home.packages = with pkgs; [
+        # Core archive manager (GNOME's archive tool)
+        file-roller
+
+        # Note: nemo-fileroller is provided by nemo-with-extensions in system config
+
+        # Additional archiving utilities for better format support
+        p7zip # 7z archives
+        unrar # RAR archives (proprietary)
+        zip # ZIP creation
+        unzip # ZIP extraction (already in system base)
+
+        # Optional: Advanced archive tools
+        kdePackages.ark # KDE's archive manager (alternative GUI, Qt6 version)
+        atool # Command-line archive tool wrapper
+      ];
+
+      # Create custom Nemo actions for archiving (more reliable than nemo-fileroller)
+      home.file.".local/share/nemo/actions/compress-files.nemo_action".text = ''
+        [Nemo Action]
+        Name=Compress...
+        Comment=Create archive with selected files
+        Exec=file-roller --add %F
+        Icon-Name=archive-manager
+        Selection=any
+        Extensions=nodirs;
+        Dependencies=file-roller;
+      '';
+
+      home.file.".local/share/nemo/actions/compress-folder.nemo_action".text = ''
+        [Nemo Action]
+        Name=Compress Folder...
+        Comment=Create archive with selected folder
+        Exec=file-roller --add %F
+        Icon-Name=archive-manager
+        Selection=any
+        Extensions=dir;
+        Dependencies=file-roller;
+      '';
+
+      home.file.".local/share/nemo/actions/extract-archive.nemo_action".text = ''
+        [Nemo Action]
+        Name=Extract Here
+        Comment=Extract archive to current directory
+        Exec=file-roller --extract-here %F
+        Icon-Name=archive-manager
+        Selection=s
+        Extensions=7z;ace;ar;arc;arj;bz;bz2;cab;cpio;deb;gz;jar;lha;lhz;lrz;lz;lzma;lzo;rar;rpm;rz;t7z;tar;tbz;tbz2;tgz;tlz;txz;tZ;tzo;war;xz;Z;zip;zoo;
+        Dependencies=file-roller;
+      '';
+
+      home.file.".local/share/nemo/actions/extract-archive-to.nemo_action".text = ''
+        [Nemo Action]
+        Name=Extract To...
+        Comment=Extract archive to chosen directory
+        Exec=file-roller --extract %F
+        Icon-Name=archive-manager
+        Selection=s
+        Extensions=7z;ace;ar;arc;arj;bz;bz2;cab;cpio;deb;gz;jar;lha;lhz;lrz;lz;lzma;lzo;rar;rpm;rz;t7z;tar;tbz;tbz2;tgz;tlz;txz;tZ;tzo;war;xz;Z;zip;zoo;
+        Dependencies=file-roller;
+      '';
+
+      # Configure file associations for archive formats
+      xdg.mimeApps.defaultApplications = {
+        # Archive formats -> File Roller
+        "application/zip" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-7z-compressed" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-rar" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-tar" = [ "org.gnome.FileRoller.desktop" ];
+        "application/gzip" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-bzip2" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-xz" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-compressed-tar" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-bzip-compressed-tar" = [ "org.gnome.FileRoller.desktop" ];
+        "application/x-xz-compressed-tar" = [ "org.gnome.FileRoller.desktop" ];
+      };
+    };
+  };
+}

--- a/modules/features/protonmail-bridge.nix
+++ b/modules/features/protonmail-bridge.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    ;
+  cfg = config.modules.features.protonmail-bridge;
+in
+{
+  options.modules.features.protonmail-bridge = {
+    enable = mkEnableOption "ProtonMail Bridge for email client integration";
+
+    username = mkOption {
+      type = types.str;
+      default = "admin";
+      description = "Username for ProtonMail Bridge CLI (if needed)";
+    };
+
+    password = mkOption {
+      type = types.str;
+      default = "password";
+      description = "Password for ProtonMail Bridge CLI (if needed)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home-manager.users.${userVars.username} = {
+      home.packages = with pkgs; [ protonmail-bridge ];
+
+      # Optionally, write credentials to a file or set env vars here if needed by the CLI
+      # home.sessionVariables = {
+      #   PROTONMAIL_BRIDGE_USERNAME = cfg.username;
+      #   PROTONMAIL_BRIDGE_PASSWORD = cfg.password;
+      # };
+    };
+  };
+}

--- a/systems/orion/default.nix
+++ b/systems/orion/default.nix
@@ -157,6 +157,13 @@ in
       brave.enable = true;
       firefox.enable = true;
       librewolf.enable = true;
+      # Utilities
+      archiver.enable = true;
+      protonmail-bridge = {
+        enable = true;
+        username = "admin";
+        password = "password";
+      };
     };
 
     services = {

--- a/systems/orion/homes/syg.nix
+++ b/systems/orion/homes/syg.nix
@@ -70,15 +70,9 @@
     # hyprpanel, waybar, hypridle, screenshots now managed by unified features in system config
     # git, kitty, btop, devenv, vscode now managed by unified features in system config
     # brave, firefox, librewolf now managed by unified features in system config
+    # archiver, protonmail-bridge now managed by unified features in system config
 
     # mullvad-browser now managed by unified features.mullvad module in system config
-    archiver.enable = true; # Enable archive management with Nemo integration
-
-    protonmail-bridge = {
-      enable = true;
-      username = "admin";
-      password = "password";
-    };
   };
 
   # Declarative Flatpak management


### PR DESCRIPTION
## Summary

Migrates archiver and protonmail-bridge from split home modules to unified feature modules, completing Phase 2 utilities migration.

## Changes

### New Unified Feature Modules
- **modules/features/archiver.nix** - Archive management with:
  - File-roller (GNOME archive manager) and supporting tools (p7zip, unrar, zip, atool, ark)
  - Custom Nemo file manager actions (compress files/folders, extract here/to)
  - MIME type associations for all common archive formats
  - Full integration with Nemo file manager
- **modules/features/protonmail-bridge.nix** - ProtonMail Bridge for email client integration with configurable username/password options

### Configuration Updates
- **systems/orion/default.nix** - Enable utility features in unified features section
- **systems/orion/homes/syg.nix** - Remove old utility enables from split home modules

## Testing

- ✅ `nix flake check --no-build` passes
- ✅ `nixos-rebuild build --flake .#orion` succeeds
- ⏳ Post-merge: system switch and utility verification

## Progress

**Phase 2: 17/31 modules migrated** (55%)

**Completed groups:**
- Core tools: zsh, mullvad (2)
- Hyprland ecosystem: hyprland, hyprpanel, hypridle, waybar, screenshots (5)
- Development tools: git, kitty, btop, devenv, vscode (5)
- Web browsers: brave, firefox, librewolf (3)
- **Utilities: archiver, protonmail-bridge (2)** ← **NEW**

**Remaining (~14 modules):**
- System services: ~6 modules (containerization, virtualization, flatpak, printing, xserver, syncthing)
- Others: ~8 modules

## Notes

Both utilities maintain their original functionality:
- **Archiver**: Full Nemo integration with context menu actions for compression and extraction
- **ProtonMail Bridge**: Email bridge service with configurable credentials (currently using placeholder values)