### PR TITLE
Phase 2: Migrate system services to unified features

### DIFF
--- a/modules/features/containerization.nix
+++ b/modules/features/containerization.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    ;
+  cfg = config.modules.features.containerization;
+in
+{
+  options.modules.features.containerization = {
+    enable = mkEnableOption "containerization with Podman or Docker";
+
+    service = mkOption {
+      type = types.enum [
+        "podman"
+        "docker"
+      ];
+      default = "podman";
+      description = "The containerization service to use (either podman or docker).";
+    };
+  };
+
+  config = mkIf cfg.enable (
+    mkIf (cfg.service == "podman") {
+      # Podman
+      virtualisation = {
+        containers.enable = true;
+
+        podman = {
+          enable = true;
+
+          # Create a `docker` alias for podman, to use it as a drop-in replacement
+          dockerCompat = true;
+
+          # Required for containers under podman-compose to be able to talk to each other.
+          defaultNetwork.settings.dns_enabled = true;
+        };
+      };
+
+      environment = {
+        systemPackages = with pkgs; [
+          dive # look into docker image layers
+          podman-tui # status of containers in the terminal
+          docker-compose # start group of containers for dev
+          #podman-compose # start group of containers for dev
+          podman-desktop
+        ];
+
+        # for running rootless podman
+        extraInit = ''
+          if [ -z "$DOCKER_HOST" -a -n "$XDG_RUNTIME_DIR" ]; then
+            export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
+          fi
+        '';
+      };
+      # } // mkIf (cfg.service == "docker") {
+      # not currently supported
+    }
+  );
+}

--- a/modules/features/flatpak.nix
+++ b/modules/features/flatpak.nix
@@ -1,0 +1,19 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.modules.features.flatpak;
+in
+{
+  options.modules.features.flatpak.enable =
+    mkEnableOption "Flatpak application sandboxing and distribution";
+
+  config = mkIf cfg.enable {
+    # Enable the system flatpak service
+    services.flatpak.enable = true;
+  };
+}

--- a/modules/features/printing.nix
+++ b/modules/features/printing.nix
@@ -1,0 +1,138 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    mkMerge
+    types
+    ;
+  cfg = config.modules.features.printing;
+in
+{
+  options.modules.features.printing = {
+    enable = mkEnableOption "CUPS printing service with comprehensive USB printer support";
+
+    enableAutoDiscovery = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable automatic discovery of network printers via Avahi";
+    };
+
+    enableSharing = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable printer sharing over the network";
+    };
+
+    enableGuiTools = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable additional GUI tools for printer and scanner management";
+    };
+
+    drivers = mkOption {
+      type = types.listOf types.package;
+      default = with pkgs; [
+        # Generic drivers for most printers
+        gutenprint
+
+        # HP printer drivers
+        hplip
+
+        # Generic PostScript and PCL drivers
+        ghostscript
+      ];
+      description = "List of printer driver packages to install";
+    };
+
+    extraDrivers = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = "Additional printer drivers to install beyond the default set";
+    };
+
+    logLevel = mkOption {
+      type = types.enum [
+        "error"
+        "warn"
+        "info"
+        "debug"
+        "debug2"
+      ];
+      default = "info";
+      description = "CUPS logging level";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = "Additional CUPS configuration";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    # Basic CUPS configuration
+    {
+      services.printing = {
+        enable = true;
+        logLevel = cfg.logLevel;
+        drivers = cfg.drivers ++ cfg.extraDrivers;
+        extraConf = cfg.extraConfig;
+      };
+
+      # Enable system-config-printer for GUI management
+      programs.system-config-printer.enable = true;
+
+      # Add useful printer management tools
+      environment.systemPackages =
+        with pkgs;
+        [
+          cups
+          system-config-printer
+        ]
+        ++ lib.optionals cfg.enableGuiTools [
+          # Additional GUI and CLI tools
+          simple-scan # Scanning application
+          hplip # HP printer management GUI (hp-toolbox)
+          gtk3 # Ensure GTK3 support for printer dialogs
+        ];
+    }
+
+    # Auto-discovery configuration
+    (mkIf cfg.enableAutoDiscovery {
+      services.avahi = {
+        enable = true;
+        nssmdns4 = true;
+        openFirewall = true;
+      };
+    })
+
+    # Printer sharing configuration
+    (mkIf cfg.enableSharing {
+      services.avahi = {
+        enable = true;
+        nssmdns4 = true;
+        openFirewall = true;
+        publish = {
+          enable = true;
+          userServices = true;
+        };
+      };
+
+      services.printing = {
+        listenAddresses = [ "*:631" ];
+        allowFrom = [ "all" ];
+        browsing = true;
+        defaultShared = true;
+        openFirewall = true;
+      };
+    })
+  ]);
+}

--- a/modules/features/syncthing.nix
+++ b/modules/features/syncthing.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    ;
+  cfg = config.modules.features.syncthing;
+in
+{
+  options.modules.features.syncthing = {
+    enable = mkEnableOption "Syncthing file synchronization service";
+
+    username = mkOption {
+      type = types.str;
+      default = userVars.username;
+      description = "Username for running Syncthing service and GUI access";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services = {
+      syncthing = {
+        enable = true;
+        user = cfg.username; # Run as this user
+        group = "users"; # Group for the user
+        dataDir = "/home/${cfg.username}/.local/share/syncthing";
+        configDir = "/home/${cfg.username}/.config/syncthing";
+        openDefaultPorts = false; # Don't auto-open ports to internet
+        settings.gui = {
+          user = "${cfg.username}";
+          # Password is managed by sops-nix secret at runtime
+          # The secret file is available at: config.sops.secrets."syg/syncthing_password".path
+        };
+      };
+    };
+
+    # Open Syncthing ports only for LAN interfaces
+    networking.firewall.interfaces = {
+      "eth0" = {
+        allowedTCPPorts = [ 22000 ]; # Syncthing transfer protocol
+        allowedUDPPorts = [
+          22000
+          21027
+        ]; # Syncthing transfer and discovery
+      };
+      "wlp1s0" = {
+        allowedTCPPorts = [ 22000 ]; # Syncthing transfer protocol
+        allowedUDPPorts = [
+          22000
+          21027
+        ]; # Syncthing transfer and discovery
+      };
+      # Not exposed to internet - LAN interfaces only
+    };
+  };
+}

--- a/modules/features/virtualization.nix
+++ b/modules/features/virtualization.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    mkMerge
+    types
+    ;
+  cfg = config.modules.features.virtualization;
+in
+{
+  options.modules.features.virtualization = {
+    enable = mkEnableOption "virtualization with VirtualBox or QEMU/KVM";
+
+    service = mkOption {
+      type = types.enum [
+        "virtualbox"
+        "qemu"
+      ];
+      default = "virtualbox";
+      description = "The virtualization service to use (either VirtualBox or QEMU).";
+    };
+
+    username = mkOption {
+      type = types.str;
+      default = userVars.username;
+      description = "User that will have access to virtualization.";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.service == "virtualbox") {
+      # VirtualBox
+      virtualisation.virtualbox = {
+        host = {
+          enable = true;
+          enableExtensionPack = true;
+          enableKvm = true;
+          addNetworkInterface = false;
+        };
+
+        guest = {
+          enable = true;
+          dragAndDrop = true;
+          clipboard = true;
+        };
+      };
+      users.users."${cfg.username}".extraGroups = [ "vboxsf" ];
+      users.extraGroups.vboxusers.members = [ cfg.username ];
+    })
+    (mkIf (cfg.service == "qemu") {
+      # Qemu + Libvirt
+      programs.virt-manager.enable = true;
+      users.users."${cfg.username}".extraGroups = [ "libvirtd" ];
+
+      virtualisation = {
+        libvirtd = {
+          enable = true;
+          qemu = {
+            swtpm.enable = true;
+            # On current NixOS releases, libvirt's default QEMU firmware setup
+            # already includes OVMF (including the "full" OVMFFull-style image),
+            # so we do not need to add OVMF packages or options here. On older
+            # NixOS versions, you may still need to configure OVMF explicitly.
+          };
+        };
+        spiceUSBRedirection.enable = true;
+      };
+      services.spice-vdagentd.enable = true;
+
+      environment.systemPackages = with pkgs; [
+        virt-manager
+        virt-viewer
+        spice
+        spice-gtk
+        spice-protocol
+        virtio-win
+        win-spice
+        adwaita-icon-theme
+      ];
+
+      home-manager.users."${cfg.username}".dconf.settings = {
+        "org/virt-manager/virt-manager/connections" = {
+          autoconnect = [ "qemu:///system" ];
+          uris = [ "qemu:///system" ];
+        };
+      };
+    })
+  ]);
+}

--- a/modules/features/xserver.nix
+++ b/modules/features/xserver.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  userVars,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption mkIf;
+  cfg = config.modules.features.xserver;
+in
+{
+  options.modules.features.xserver.enable = mkEnableOption "X11 server support";
+
+  config = mkIf cfg.enable {
+    services.xserver = {
+      enable = true;
+
+      # Configure keymap for X11 (optional)
+      xkb = {
+        layout = "us"; # Set keymap layout
+        variant = ""; # Use the default variant
+      };
+    };
+  };
+}

--- a/systems/orion/default.nix
+++ b/systems/orion/default.nix
@@ -164,33 +164,31 @@ in
         username = "admin";
         password = "password";
       };
-    };
-
-    services = {
+      # System services
       # xserver.enable = true;
-
       syncthing = {
         enable = true;
         username = "${username}";
         # Password now managed by sops-nix secrets
       };
-
       virtualization = {
         enable = true;
         service = "qemu"; # Temporarily using QEMU (VirtualBox build failing)
         username = "${username}";
       };
-
       containerization = {
         enable = true;
         service = "podman";
       };
-
       printing = {
         enable = true;
         enableAutoDiscovery = true;
         enableSharing = false;
       };
+      flatpak.enable = true;
+    };
+
+    services = {
     };
 
     # Enable security module with sudo password requirement


### PR DESCRIPTION
## Summary

Migrates 6 system service modules to unified feature modules following the dendritic pattern:

### Migrated Services
- **containerization**: Podman/Docker support with development tools
- **virtualization**: VirtualBox/QEMU/KVM with virt-manager
- **flatpak**: Application sandboxing and distribution platform
- **printing**: CUPS printing with comprehensive printer drivers
- **xserver**: X11 server configuration
- **syncthing**: File synchronization service with firewall rules

### Changes
- Created 6 new unified feature modules in `modules/features/`
- Updated Orion configuration to use `modules.features.*` instead of `modules.services.*`
- All options and functionality preserved from original modules
- Used `userVars.username` for default username values where applicable

### Testing
- ✅ `nix flake check --no-build` passed
- ✅ `nixos-rebuild build --flake .#orion` succeeded

### Migration Progress
**Phase 2: 23/31 modules migrated (74%)**

This completes the system services migration group and reaches a major milestone in Phase 2.